### PR TITLE
Allow running under subpath while proxying in Docker image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -74,6 +74,13 @@ The only option for the UI, is the URL(s) of your Connect cluster(s).
   
       -e "CADDY_OPTIONS=basicauth / [USER] [PASS]"
 
+- `RELATIVE_PROXY_URL=[true|false]`
+  
+  When proxying Connect, enabling this option will set the Connect endpoint in the UI
+  as a relative URL. This can help when running
+  Kafka Connect UI under a subpath of your server (e.g
+  `http://url:8000/kc-ui` instead of `http://url:8000/`).
+
 # Kafka Connect Configuration
 
 If you don't wish to proxy Connect's REST api, you should permit CORS via setting

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -4,6 +4,7 @@ PROXY="${PROXY:-true}"
 PROXY_SKIP_VERIFY="${PROXY_SKIP_VERIFY:-false}"
 INSECURE_PROXY=""
 CADDY_OPTIONS="${CADDY_OPTIONS:-}"
+RELATIVE_PROXY_URL="${RELATIVE_PROXY_URL:-false}"
 PORT="${PORT:-8000}"
 
 {
@@ -61,10 +62,16 @@ proxy /api/$CLUSTER_SANITIZED_NAME $CLUSTER_URL {
     $INSECURE_PROXY
 }
 EOF
+            if echo "$RELATIVE_PROXY_URL" | egrep -sq "true|TRUE|y|Y|yes|YES|1"; then
+                CLUSTER_URL="api/$CLUSTER_SANITIZED_NAME"
+            else
+                CLUSTER_URL="/api/$CLUSTER_SANITIZED_NAME"
+            fi
+
             cat <<EOF >>/tmp/env.js
    $OPEN_CURL
      NAME: "$CLUSTER_NAME",
-     KAFKA_CONNECT: "/api/$CLUSTER_SANITIZED_NAME"
+     KAFKA_CONNECT: "$CLUSTER_URL"
    }
 EOF
         else


### PR DESCRIPTION
This is analogous to the schema-registry-ui feature enabled by the `RELATIVE_PROXY_URL` environment variable. I'd like to run Kafka Connect UI behind a reverse proxy and under a subpath with proxying enabled. As a momentary workaround, I have Connect proxied through the same server that also proxies to the UI, but I'd like to make use of the built-in proxy feature.

I've tested the changes locally and they work just like they do for the Schema Registry UI.