### PR TITLE
Fix Broken Build on Node >= 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-usemin": "^3.1.1",
+    "gulp": "^4.0.2",
     "jit-grunt": "^0.10.0"
   },
   "scripts": {
+    "preinstall": "npx npm-force-resolutions",
     "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "bower install",
     "build": "grunt && cd dist && tar cvzf kafka-connect-ui.tar.gz ."
@@ -34,5 +36,9 @@
   "bugs": {
     "url": "https://github.com/Landoop/kafka-connect-ui/issues"
   },
-  "homepage": "https://github.com/Landoop/kafka-connect-ui#readme"
+  "homepage": "https://github.com/Landoop/kafka-connect-ui#readme",
+  "resolutions": {
+    "graceful-fs": "^4.2.4"
+  }
 }
+

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-usemin": "^3.1.1",
-    "gulp": "^4.0.2",
     "jit-grunt": "^0.10.0"
   },
   "scripts": {


### PR DESCRIPTION
Fixes broken build on Node >= 12


### Issue
- During Npm Build
![image](https://user-images.githubusercontent.com/12872673/101275761-411ad400-37ce-11eb-9761-bc76e441abd3.png)



![image](https://user-images.githubusercontent.com/12872673/101275750-32342180-37ce-11eb-88c7-a4164254b4ba.png)


- `Gulp@<4.0` depends on `graceful-fs@^3.0.0`. It monkeypatches Node.js fs module.
- Hence, with Node JS >= 12, it doesn't work. Solution is to force the FS resolution

