### PR TITLE
Fix Caddy webserver github URL in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache ca-certificates wget \
     && echo "progress = dot:giga" | tee /etc/wgetrc
 
 # Add and Setup Caddy webserver
-RUN wget "https://github.com/mholt/caddy/releases/download/v0.10.11/caddy_v0.10.11_linux_amd64.tar.gz" -O /caddy.tgz \
+RUN wget "https://github.com/caddyserver/caddy/releases/download/v0.10.11/caddy_v0.10.11_linux_amd64.tar.gz" -O /caddy.tgz \
     && mkdir caddy \
     && tar xzf caddy.tgz -C /caddy --no-same-owner \
     && rm -f /caddy.tgz


### PR DESCRIPTION
I found URL for setting up Caddy webserver is not available.
You can see that `caddy` repository is NOT [`mholt/caddy`](https://github.com/mholt/caddy) but [`caddyserver/caddy`](https://github.com/caddyserver/caddy) in [here(Matt's github)](https://github.com/mholt).

I believe `docker build` command will be successful only if using https://github.com/caddyserver/caddy/releases/download/v0.10.11/caddy_v0.10.11_linux_amd64.tar.gz.
(I checked that it works properly!)