### PR TITLE
Fix connector type checker

### DIFF
--- a/src/factories/connector-objects.factory.js
+++ b/src/factories/connector-objects.factory.js
@@ -57,7 +57,7 @@ angularAPP.factory('connectorObjects', function (KafkaConnectFactory, supportedC
       }
 
       function isSource(connector) {
-        return 'Source' === configurationTypeFilter(connector.config);
+        return 'Source' === configurationTypeFilter(connector.config) || 'source' === connector.type;
       }
 
       function enhanceConnectors(connectors) {

--- a/src/kafka-connect/cluster-view/cluster-view.controller.js
+++ b/src/kafka-connect/cluster-view/cluster-view.controller.js
@@ -19,7 +19,7 @@ angularAPP.controller('ClusterViewCtrl', function ($scope, $log, $http, env, con
                 var template = connectorObjects.getConnectorTemplate(connector.config);
                 var topics = connectorObjects.getTopics(connector.config);
                 var workers = connector.config["tasks.max"];
-                var isSource = template.type == 'Source';
+                var isSource = template.type == 'Source' || connector.type === 'source';
                 var type = template.name;
                 var color = template.color;
 //                var html = createCustomHTMLContent(isSource, workers, type, color);


### PR DESCRIPTION
The connector type can be recognized by `$.type` field Since Confluent Kafka 6.2.1
This resolves Connect topology visualization at cluster home page

https://docs.confluent.io/platform/6.2.1/connect/references/restapi.html#connectors

**request**

```http
GET /connectors/{{connector-name}} HTTP/1.1
Content-Type: application/json
```

**response**
```json
{
    "name": "connector-name",
    "config": {    },
    "tasks": [    ],
    "type": "source" // here
}
```